### PR TITLE
Increase stack size on Windows to prevent stack overflow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,3 +21,7 @@ find_package(SDL3)
 target_link_libraries(GBC SDL3::SDL3)
 
 add_subdirectory(src/audio)
+
+if(WIN32)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /STACK:8000000")
+endif()


### PR DESCRIPTION
This increases the stack size to 8MB to make it work on Windows.