### PR TITLE
Execute emulator optimization plan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,13 @@ target_include_directories(GBC PUBLIC src/audio)
 
 target_compile_options(GBC PUBLIC -fwrapv)
 
+if(EMSCRIPTEN)
+    target_compile_options(GBC PUBLIC -O3 -flto)
+    target_link_options(GBC PUBLIC -O3 -flto -sASSERTIONS=0 -sDISABLE_EXCEPTION_CATCHING=1 -sMALLOC=emmalloc)
+else()
+    target_compile_options(GBC PUBLIC -O3)
+endif()
+
 find_package(SDL3)
 
 target_link_libraries(GBC SDL3::SDL3)

--- a/src/CPU/SM83.cc
+++ b/src/CPU/SM83.cc
@@ -6,7 +6,8 @@ namespace GBC {
 
     void SM83::execute() {
     increment_timer();
-    if ((memory->read(IF) & memory->read(IE)) != 0) halted = false;
+    cached_interrupt_flags = memory->read(IF) & memory->read(IE);
+    if (cached_interrupt_flags != 0) halted = false;
     if (halted) return;
 
     if (cycles > 0) {
@@ -19,39 +20,34 @@ namespace GBC {
         dump_registers();
     }
     
-    if (IME && (memory->read(IF) & memory->read(IE))) {
-        if ((memory->read(IF) & 1) && (memory->read(IE) & 1)) {
+    if (IME && cached_interrupt_flags) {
+        if ((cached_interrupt_flags & 1)) {
             IME = 0;
-
-            memory->write(IF, (memory->read(IF) & 1) & ~(1));
+            memory->write(IF, memory->read(IF) & ~(1));
             call_interrupt(0x40);
             return;
         }
-        if ((memory->read(IF) & (1 << 1)) && (memory->read(IE) & (1 << 1))) {
+        if ((cached_interrupt_flags & (1 << 1))) {
             IME = 0;
-
-            memory->write(IF, (memory->read(IF) & 1) & ~(1 << 1));
+            memory->write(IF, memory->read(IF) & ~(1 << 1));
             call_interrupt(0x48);
             return;
         }
-        if ((memory->read(IF) & (1 << 2)) && (memory->read(IE) & (1 << 2))) {
+        if ((cached_interrupt_flags & (1 << 2))) {
             IME = 0;
-
-            memory->write(IF, (memory->read(IF) & 1) & ~(1 << 2));
+            memory->write(IF, memory->read(IF) & ~(1 << 2));
             call_interrupt(0x50);
             return;
         }
-        if ((memory->read(IF) & (1 << 3)) && (memory->read(IE) & (1 << 3))) {
+        if ((cached_interrupt_flags & (1 << 3))) {
             IME = 0;
-
-            memory->write(IF, (memory->read(IF) & 1) & ~(1 << 3));
+            memory->write(IF, memory->read(IF) & ~(1 << 3));
             call_interrupt(0x58);
             return;
         }
-        if ((memory->read(IF) & (1 << 4)) && (memory->read(IE) & (1 << 4))) {
+        if ((cached_interrupt_flags & (1 << 4))) {
             IME = 0;
-
-            memory->write(IF, (memory->read(IF) & 1) & ~(1 << 4));
+            memory->write(IF, memory->read(IF) & ~(1 << 4));
             call_interrupt(0x60);
             return;
         }

--- a/src/CPU/SM83.cc
+++ b/src/CPU/SM83.cc
@@ -991,11 +991,11 @@ namespace GBC {
     }
     
     inline void SM83::instrLDH_C_A() {
-        memory->write(0xFF00 + RC, RA);
+        memory->write(IO_REGISTERS + RC, RA);
     }
     
     inline void SM83::instrLDH_Imm8_A() {
-        memory->write(0xFF00 | fetch8(), RA);
+        memory->write(IO_REGISTERS | fetch8(), RA);
     }
     
     inline void SM83::instrLD_Imm16_A() {
@@ -1004,11 +1004,11 @@ namespace GBC {
     }
     
     inline void SM83::instrLDH_A_C() {
-        RA = memory->read(0xFF00 | RC);  
+        RA = memory->read(IO_REGISTERS | RC);  
     }
     
     inline void SM83::instrLDH_A_Imm8() {
-        RA = memory->read(0xFF00 | fetch8());
+        RA = memory->read(IO_REGISTERS | fetch8());
     }
     
     inline void SM83::instrLD_A_Imm16() {

--- a/src/CPU/SM83.cc
+++ b/src/CPU/SM83.cc
@@ -21,31 +21,32 @@ namespace GBC {
     }
     
     if (IME && cached_interrupt_flags) {
-        if ((cached_interrupt_flags & 1)) {
+        uint8_t pending = cached_interrupt_flags;
+        if (pending & 1) {
             IME = 0;
             memory->write(IF, memory->read(IF) & ~(1));
             call_interrupt(0x40);
             return;
         }
-        if ((cached_interrupt_flags & (1 << 1))) {
+        if (pending & (1 << 1)) {
             IME = 0;
             memory->write(IF, memory->read(IF) & ~(1 << 1));
             call_interrupt(0x48);
             return;
         }
-        if ((cached_interrupt_flags & (1 << 2))) {
+        if (pending & (1 << 2)) {
             IME = 0;
             memory->write(IF, memory->read(IF) & ~(1 << 2));
             call_interrupt(0x50);
             return;
         }
-        if ((cached_interrupt_flags & (1 << 3))) {
+        if (pending & (1 << 3)) {
             IME = 0;
             memory->write(IF, memory->read(IF) & ~(1 << 3));
             call_interrupt(0x58);
             return;
         }
-        if ((cached_interrupt_flags & (1 << 4))) {
+        if (pending & (1 << 4)) {
             IME = 0;
             memory->write(IF, memory->read(IF) & ~(1 << 4));
             call_interrupt(0x60);

--- a/src/CPU/SM83.h
+++ b/src/CPU/SM83.h
@@ -29,6 +29,7 @@ namespace GBC {
         uint16_t opcode = 0;
         uint8_t cycles = 0;
         bool IME = false, IMEdelay = false, halted = false, stathigh = false;
+        uint8_t cached_interrupt_flags = 0;
 
         void execute();
         inline void executeCB();

--- a/src/CPU/SM83.h
+++ b/src/CPU/SM83.h
@@ -37,35 +37,35 @@ namespace GBC {
         //===========================================================
         // Flag accessors – F is stored in r8[6]
         //===========================================================
-        inline bool getZeroFlag() const       { return (r8[6] >> 7) & 1; }
-        inline bool getNFlag() const          { return (r8[6] >> 6) & 1; }
-        inline bool getHalfCarryFlag() const  { return (r8[6] >> 5) & 1; }
-        inline bool getCarryFlag() const      { return (r8[6] >> 4) & 1; }
+        [[gnu::always_inline]] inline bool getZeroFlag() const       { return (r8[6] >> 7) & 1; }
+        [[gnu::always_inline]] inline bool getNFlag() const          { return (r8[6] >> 6) & 1; }
+        [[gnu::always_inline]] inline bool getHalfCarryFlag() const  { return (r8[6] >> 5) & 1; }
+        [[gnu::always_inline]] inline bool getCarryFlag() const      { return (r8[6] >> 4) & 1; }
 
-        inline void setZeroFlag(bool val)     { r8[6] = (r8[6] & ~(1 << 7)) | ((val ? 1 : 0) << 7); }
-        inline void setNFlag(bool val)        { r8[6] = (r8[6] & ~(1 << 6)) | ((val ? 1 : 0) << 6); }
-        inline void setHalfCarryFlag(bool val){ r8[6] = (r8[6] & ~(1 << 5)) | ((val ? 1 : 0) << 5); }
-        inline void setCarryFlag(bool val)    { r8[6] = (r8[6] & ~(1 << 4)) | ((val ? 1 : 0) << 4); }
+        [[gnu::always_inline]] inline void setZeroFlag(bool val)     { r8[6] = (r8[6] & ~(1 << 7)) | ((val ? 1 : 0) << 7); }
+        [[gnu::always_inline]] inline void setNFlag(bool val)        { r8[6] = (r8[6] & ~(1 << 6)) | ((val ? 1 : 0) << 6); }
+        [[gnu::always_inline]] inline void setHalfCarryFlag(bool val){ r8[6] = (r8[6] & ~(1 << 5)) | ((val ? 1 : 0) << 5); }
+        [[gnu::always_inline]] inline void setCarryFlag(bool val)    { r8[6] = (r8[6] & ~(1 << 4)) | ((val ? 1 : 0) << 4); }
 
         //===========================================================
         // Register-pair accessors
         //===========================================================
-        inline uint16_t getAF() const { return (r8[7] << 8) | r8[6]; }
-        inline uint16_t getBC() const { return (r8[0] << 8) | r8[1]; }
-        inline uint16_t getDE() const { return (r8[2] << 8) | r8[3]; }
-        inline uint16_t getHL() const { return (r8[4] << 8) | r8[5]; }
-        inline void setAF(uint16_t val) { r8[7] = val >> 8; r8[6] = val & 0xF0; } // lower nibble of F always 0
-        inline void setBC(uint16_t val) { r8[0] = val >> 8; r8[1] = val & 0xFF; }
-        inline void setDE(uint16_t val) { r8[2] = val >> 8; r8[3] = val & 0xFF; }
-        inline void setHL(uint16_t val) { r8[4] = val >> 8; r8[5] = val & 0xFF; }
+        [[gnu::always_inline]] inline uint16_t getAF() const { return (r8[7] << 8) | r8[6]; }
+        [[gnu::always_inline]] inline uint16_t getBC() const { return (r8[0] << 8) | r8[1]; }
+        [[gnu::always_inline]] inline uint16_t getDE() const { return (r8[2] << 8) | r8[3]; }
+        [[gnu::always_inline]] inline uint16_t getHL() const { return (r8[4] << 8) | r8[5]; }
+        [[gnu::always_inline]] inline void setAF(uint16_t val) { r8[7] = val >> 8; r8[6] = val & 0xF0; }
+        [[gnu::always_inline]] inline void setBC(uint16_t val) { r8[0] = val >> 8; r8[1] = val & 0xFF; }
+        [[gnu::always_inline]] inline void setDE(uint16_t val) { r8[2] = val >> 8; r8[3] = val & 0xFF; }
+        [[gnu::always_inline]] inline void setHL(uint16_t val) { r8[4] = val >> 8; r8[5] = val & 0xFF; }
 
         //===========================================================
         // Fetch functions
         //===========================================================
-        inline uint8_t fetch8() {
+        [[gnu::always_inline]] inline uint8_t fetch8() {
             return memory->read(pc++);
         }
-        inline uint16_t fetch16() {
+        [[gnu::always_inline]] inline uint16_t fetch16() {
             uint16_t result = memory->read(pc) | (memory->read(pc + 1) << 8);
             pc += 2;
             return result;

--- a/src/GBC.cc
+++ b/src/GBC.cc
@@ -64,31 +64,33 @@ namespace GBC {
     }
 
     inline void GBC::handle_input() {
+#ifndef __EMSCRIPTEN__
         byte input_s = 0xF0, input_d = 0xF0;
 
-        if (SDL_GetKeyboardState(nullptr)[SDL_SCANCODE_A]) {
+        const uint8_t* keyboard_state = SDL_GetKeyboardState(nullptr);
+        if (keyboard_state[SDL_SCANCODE_A]) {
             input_s |= 1;
         }
-        if (SDL_GetKeyboardState(nullptr)[SDL_SCANCODE_S]) {
+        if (keyboard_state[SDL_SCANCODE_S]) {
             input_s |= (1 << 1);
         }
-        if (SDL_GetKeyboardState(nullptr)[SDL_SCANCODE_Z]) {
-            input_s |= (1 << 2); //select
+        if (keyboard_state[SDL_SCANCODE_Z]) {
+            input_s |= (1 << 2);
         }
-        if (SDL_GetKeyboardState(nullptr)[SDL_SCANCODE_X]) {
-            input_s |= (1 << 3); //start
+        if (keyboard_state[SDL_SCANCODE_X]) {
+            input_s |= (1 << 3);
         }
 
-        if (SDL_GetKeyboardState(nullptr)[SDL_SCANCODE_RIGHT]) {
+        if (keyboard_state[SDL_SCANCODE_RIGHT]) {
             input_d |= 1;
         }
-        if (SDL_GetKeyboardState(nullptr)[SDL_SCANCODE_LEFT]) {
+        if (keyboard_state[SDL_SCANCODE_LEFT]) {
             input_d |= (1 << 1);
         }
-        if (SDL_GetKeyboardState(nullptr)[SDL_SCANCODE_UP]) {
+        if (keyboard_state[SDL_SCANCODE_UP]) {
             input_d |= (1 << 2);
         }
-        if (SDL_GetKeyboardState(nullptr)[SDL_SCANCODE_DOWN]) {
+        if (keyboard_state[SDL_SCANCODE_DOWN]) {
             input_d |= (1 << 3); 
         }
 
@@ -96,9 +98,18 @@ namespace GBC {
             addresses.write(IF, addresses.read(IF) | (1 << 4));
         }
 
-
         addresses.input_d = ~input_d;
         addresses.input_s = ~input_s;
+#endif
+    }
+
+    void GBC::execute_frame() {
+        handle_input();
+        for (int i = 0; i < 70224; ++i) {
+            ppu.execute_cycle();
+            cpu.execute();
+            ++cycle_count;
+        }
     }
 
     inline void GBC::execute_cycle() {
@@ -107,20 +118,22 @@ namespace GBC {
 
         ++cycle_count;
 
+#ifndef __EMSCRIPTEN__
         if (cycle_count % 100 == 0) handle_input();
+#endif
     }
 
     inline void GBC::debug_execute_cycle(uint32_t freq) {
         execute_cycle();
 
+#ifndef __EMSCRIPTEN__
         if (SDL_GetKeyboardState(nullptr)[SDL_SCANCODE_D]) {
             debug_flag = 1;
         }
         if (debug_flag && cpu.cycles == 0) { 
-            // std::cout << std::dec << cycle_count << std::hex << std::endl; 
             dump_stuff();
         }
-
+#endif
     }
 
     inline void GBC::dump_stuff() {

--- a/src/GBC.cc
+++ b/src/GBC.cc
@@ -40,11 +40,12 @@ namespace GBC {
             ++frame;
 
             // frame, TODO move out into function
-            for (int i = 0; i < 70224; ++i) {
-                execute_cycle();
-
+            for (int i = 0; i < 70224; ) {
+                int batch_size = 100;
+                for (int j = 0; j < batch_size && i < 70224; ++j, ++i) {
+                    execute_cycle();
+                }
                 if (ppu.mode == vblank) {
-
                     break;
                 }
             } 
@@ -109,6 +110,9 @@ namespace GBC {
             ppu.execute_cycle();
             cpu.execute();
             ++cycle_count;
+            if ((i % 100 == 0) && ppu.mode == vblank && i > 0) {
+                break;
+            }
         }
     }
 

--- a/src/GBC.h
+++ b/src/GBC.h
@@ -1,16 +1,15 @@
 #pragma once 
 
-#include <stdlib.h>
-#include <assert.h>
+#include <cstdint>
+#include <cstdlib>
 #include <cstring>
+#include <cassert>
+#include <thread>
 
 #include "CPU/SM83.h"
-
 #include "MMU/bus.h"
 #include "video/PPU.h"
 #include "bus.h"
-
-#include <thread>
 
 namespace GBC {
     using namespace std::chrono_literals;

--- a/src/GBC.h
+++ b/src/GBC.h
@@ -22,7 +22,7 @@ namespace GBC {
             void run();
             void start_window();
             void execute_frame();
-            inline void execute_cycle();
+            [[gnu::always_inline]] inline void execute_cycle();
             inline void debug_execute_cycle(uint32_t freq);
             inline void dump_stuff();
             inline void handle_input();

--- a/src/GBC.h
+++ b/src/GBC.h
@@ -21,6 +21,7 @@ namespace GBC {
             void start();
             void run();
             void start_window();
+            void execute_frame();
             inline void execute_cycle();
             inline void debug_execute_cycle(uint32_t freq);
             inline void dump_stuff();

--- a/src/MMU/bus.cc
+++ b/src/MMU/bus.cc
@@ -39,29 +39,15 @@ namespace GBC {
     
     // TODO: Benchmark how slow this is. Might stop using it in static contexts, I'll see how well the compiler optimizes it. Also probably want to implement mask read/writes
     byte address_bus::read(half address) {
-        if (address < 0x0100 && booting) {
-            return bootrom[address];
-        }
-
         if (address <= END_ROM_BANK_00) {
+            if (address < 0x0100 && booting) {
+                return bootrom[address];
+            }
             return cartROM[address];
         }
 
         if (address >= ROM_BANK_NN && address <= END_ROM_BANK_NN) {
             return cartROM[address+16*KB*(rom_bank & 0x7F)-ROM_BANK_NN];
-        }
-
-        if (address >= VIDEO_RAM && address <= END_VIDEO_RAM) {
-            if (lcd_mode == draw) return 0xFF;
-            return videoRAM[address+vram_bank*8*KB-VIDEO_RAM]; 
-        }
-
-        if (address >= EXTERNAL_RAM && address <=END_EXTERNAL_RAM) {
-            return cartRAM[address+8*KB*eram_bank-EXTERNAL_RAM];
-        }
-          
-        if (address >= ECHO_RAM1 && address <= EECHO_RAM2) {
-            address-=0x2000;
         }
 
         if (address >= WORK_RAM_BANK0 && address <= END_WORK_RAM_BANK0) {
@@ -70,6 +56,19 @@ namespace GBC {
 
         if (address >= WORK_RAM_BANKN && address <= END_WORK_RAM_BANKN) {
             return workRAM[address+wram_bank*4*KB-WORK_RAM_BANKN]; 
+        }
+
+        if (address >= ECHO_RAM1 && address <= EECHO_RAM2) {
+            address-=0x2000;
+            if (address >= WORK_RAM_BANK0 && address <= END_WORK_RAM_BANK0) {
+                return workRAM[address-WORK_RAM_BANK0];
+            }
+            return workRAM[address+wram_bank*4*KB-WORK_RAM_BANKN];
+        }
+
+        if (address >= VIDEO_RAM && address <= END_VIDEO_RAM) {
+            if (lcd_mode == draw) return 0xFF;
+            return videoRAM[address+vram_bank*8*KB-VIDEO_RAM]; 
         }
 
         if (address >= OAMaddress && address <= END_OAM) {
@@ -83,6 +82,10 @@ namespace GBC {
 
         if (address >= HIGH_RAM && address <= END_HIGH_RAM) {
             return HRAM[address-HIGH_RAM];
+        }
+
+        if (address >= EXTERNAL_RAM && address <=END_EXTERNAL_RAM) {
+            return cartRAM[address+8*KB*eram_bank-EXTERNAL_RAM];
         }
 
         if (address >= NOT_USUABLE && address <= END_NOT_USUABLE) {
@@ -166,16 +169,6 @@ namespace GBC {
     }
 
     void address_bus::write(half address, byte value) {
-        if (address >= VIDEO_RAM && address <= END_VIDEO_RAM) {
-            if (lcd_mode == draw) return;
-            videoRAM[address+vram_bank*8*KB-VIDEO_RAM] = value;
-            return;
-        }
-
-        if (address >= ECHO_RAM1 && address <= EECHO_RAM2) {
-            address-=0x2000;
-        }
-
         if (address >= WORK_RAM_BANK0 && address <= END_WORK_RAM_BANK0) {
             workRAM[address-WORK_RAM_BANK0] = value;
             return;
@@ -186,15 +179,25 @@ namespace GBC {
             return;
         }
 
+        if (address >= ECHO_RAM1 && address <= EECHO_RAM2) {
+            address-=0x2000;
+            if (address >= WORK_RAM_BANK0 && address <= END_WORK_RAM_BANK0) {
+                workRAM[address-WORK_RAM_BANK0] = value;
+                return;
+            }
+            workRAM[address+wram_bank*4*KB-WORK_RAM_BANKN] = value;
+            return;
+        }
+
+        if (address >= VIDEO_RAM && address <= END_VIDEO_RAM) {
+            if (lcd_mode == draw) return;
+            videoRAM[address+vram_bank*8*KB-VIDEO_RAM] = value;
+            return;
+        }
+
         if (address >= OAMaddress && address <= END_OAM) {
             if (lcd_mode == draw || lcd_mode == OAMscan) return;
             OAM[address-OAMaddress] = value;
-            return;
-        }
-        
-        if (address >= EXTERNAL_RAM && address <= END_EXTERNAL_RAM) {
-            if (RAMenable) 
-               cartRAM[address+8*KB*eram_bank-EXTERNAL_RAM] = value;
             return;
         }
 
@@ -205,6 +208,12 @@ namespace GBC {
 
         if (address >= HIGH_RAM && address <= END_HIGH_RAM) {
             HRAM[address-HIGH_RAM] = value;
+            return;
+        }
+
+        if (address >= EXTERNAL_RAM && address <= END_EXTERNAL_RAM) {
+            if (RAMenable) 
+               cartRAM[address+8*KB*eram_bank-EXTERNAL_RAM] = value;
             return;
         }
 

--- a/src/video/PPU.cc
+++ b/src/video/PPU.cc
@@ -85,10 +85,10 @@ namespace GBC {
                     byte objsize = (cached_LCDC & (1 << 2)) ? 16 : 8;
                     
                     for (int16_t i = 0x00; i < 0x9F; i+=4) {
-                        byte objy = bus->read_privledged(0xFE00+i)-16,
-                        objx = bus->read_privledged(0xFE00+i+1),
-                        index = bus->read_privledged(0xFE00+i+2),
-                        flags = bus->read_privledged(0xFE00+i+3); 
+                        byte objy = bus->read_privledged(OAMaddress+i)-16,
+                        objx = bus->read_privledged(OAMaddress+i+1),
+                        index = bus->read_privledged(OAMaddress+i+2),
+                        flags = bus->read_privledged(OAMaddress+i+3); 
                         if (objy <= lines && objy+objsize > lines) {
                             objbuffer[objnum].objx = objx,
                             objbuffer[objnum].objy = objy,
@@ -248,7 +248,7 @@ namespace GBC {
              prio = flags & (1 << 7);
 
 
-        half tile_address = 0x8000+index*16 + (Yflip ? (objsize-1-(lines-objy))*2 : (lines-objy)*2); // TODO extract into function, maybe?
+        half tile_address = VIDEO_RAM+index*16 + (Yflip ? (objsize-1-(lines-objy))*2 : (lines-objy)*2);
 
         byte tilelow = bus->read(tile_address),
             tilehigh = bus->read(tile_address+1);
@@ -275,8 +275,8 @@ namespace GBC {
         uint8_t tilex_mod8 = tilex & 7;
 
         if (data_area != 0) {
-            tilelow = bus->read(tile_index*16+tiley_mod8*2+0x8000);
-            tilehigh = bus->read(tile_index*16+tiley_mod8*2+1+0x8000);
+            tilelow = bus->read(tile_index*16+tiley_mod8*2+VIDEO_RAM);
+            tilehigh = bus->read(tile_index*16+tiley_mod8*2+1+VIDEO_RAM);
         } else {
             tilelow = bus->read(tiley_mod8*2+0x9000+((int8_t)tile_index)*16);
             tilehigh = bus->read(tiley_mod8*2+1+0x9000+((int8_t)tile_index)*16);
@@ -301,8 +301,8 @@ namespace GBC {
         uint8_t tilex_mod8 = tilex & 7;
 
         if (data_area) {
-            tilelow = bus->read(tile_index*16+tiley_mod8*2+0x8000);
-            tilehigh = bus->read(tile_index*16+tiley_mod8*2+1+0x8000);
+            tilelow = bus->read(tile_index*16+tiley_mod8*2+VIDEO_RAM);
+            tilehigh = bus->read(tile_index*16+tiley_mod8*2+1+VIDEO_RAM);
         } else {
             if (tile_index <= 127) {
                 tilelow = bus->read(tiley_mod8*2+0x9000+tile_index*16);

--- a/src/video/PPU.cc
+++ b/src/video/PPU.cc
@@ -43,25 +43,46 @@ namespace GBC {
         SDL_Quit();
     }
 
+    inline void PPU::update_register_cache() {
+        cached_LCDC = bus->read(LCDC);
+        cached_BGP = bus->read(BGP);
+        cached_OBP0 = bus->read(OBP0);
+        cached_OBP1 = bus->read(OBP1);
+        cached_SCX = bus->read(SCX);
+        cached_SCY = bus->read(SCY);
+        cached_WX = bus->read(WX);
+        cached_WY = bus->read(WY);
+        cached_LYC = bus->read(LYC);
+        lyc_match = (lines == cached_LYC);
+        cache_dirty = false;
+    }
+
     void PPU::execute_cycle() {
-        if (dots >= 456) ++lines;
+        if (dots >= 456) {
+            ++lines;
+            lyc_match = (lines == cached_LYC);
+        }
         dots %= 456;
         lines %= 154;
 
-        if ((bus->read(LCDC)&0x80) == 0) {
-            bus->IOrange[STAT-IO_REGISTERS] = (bus->IOrange[STAT-IO_REGISTERS] & 0xF8) | 0 | ((lines == bus->read(LYC)) << 2); 
+        if (dots == 0 || cache_dirty) {
+            update_register_cache();
+        }
+
+        if ((cached_LCDC&0x80) == 0) {
+            bus->IOrange[STAT-IO_REGISTERS] = (bus->IOrange[STAT-IO_REGISTERS] & 0xF8) | 0 | (lyc_match << 2); 
             return;
         }
         bus->write(IF, bus->read(IF) & ~(1 << 1));
         bus->IOrange[LY-IO_REGISTERS] = lines;
-        if (bus->read(STAT) & (1 << 6) && (lines == bus->read(LYC))) bus->write(IF, bus->read(IF) | (1 << 1));
+        if (bus->read(STAT) & (1 << 6) && lyc_match) bus->write(IF, bus->read(IF) | (1 << 1));
 
         if (lines < 144) {
-            if ((dots%456) < 80) {
+            if (dots < 80) {
                 if (mode != OAMscan) {
                     objnum = 0;
                     mode = OAMscan; 
-                    byte objsize = (bus->read(LCDC) & (1 << 2)) ? 16 : 8;
+                    byte objsize = (cached_LCDC & (1 << 2)) ? 16 : 8;
                     
                     for (int16_t i = 0x00; i < 0x9F; i+=4) {
                         byte objy = bus->read_privledged(0xFE00+i)-16,
@@ -80,17 +101,19 @@ namespace GBC {
                         if (objnum == 10) break;
                     }
                     std::sort(objbuffer, objbuffer+objnum, [](obj a, obj b){return a.objx < b.objx;});
-                    bus->IOrange[STAT-IO_REGISTERS] = (bus->IOrange[STAT-IO_REGISTERS] & 0xF8) | 2 | ((lines == bus->read(LYC)) << 2);  
+                    bus->IOrange[STAT-IO_REGISTERS] = (bus->IOrange[STAT-IO_REGISTERS] & 0xF8) | 2 | (lyc_match << 2);  
                     if (bus->read(STAT) & (1 << 5)) bus->write(IF, bus->read(IF) | (1 << 1)); // TODO extract into function
 
                 }
 
-            } else if ((dots%456) < 252) {
+            } else if (dots < 252) {
                 if (mode != draw) {
                     mode = draw;
                     wlyenabled = false;
+#ifndef NDEBUG
                     debug_callback = true;
-                    bus->IOrange[STAT-IO_REGISTERS] = (bus->IOrange[STAT-IO_REGISTERS] & 0xF8) | 3 | ((lines == bus->read(LYC)) << 2);
+#endif
+                    bus->IOrange[STAT-IO_REGISTERS] = (bus->IOrange[STAT-IO_REGISTERS] & 0xF8) | 3 | (lyc_match << 2);
                 }
 
                 draw_pixel();
@@ -101,7 +124,7 @@ namespace GBC {
                     if (wlyenabled) {
                         ++wly;
                     }
-                bus->IOrange[STAT-IO_REGISTERS] = (bus->IOrange[STAT-IO_REGISTERS] & 0xF8) | 0 | ((lines == bus->read(LYC)) << 2);
+                bus->IOrange[STAT-IO_REGISTERS] = (bus->IOrange[STAT-IO_REGISTERS] & 0xF8) | 0 | (lyc_match << 2);
 
                     if (bus->read(STAT) & (1 << 3)) bus->write(IF, bus->read(IF) | (1 << 1));
                 }
@@ -114,7 +137,7 @@ namespace GBC {
                 bus->write(IF, bus->read(IF) | 1);
                 SDL_RenderPresent(renderer);
                 if (bus->read(STAT) & (1 << 4)) bus->write(IF, bus->read(IF) | (1 << 1));
-            bus->IOrange[STAT-IO_REGISTERS] = (bus->IOrange[STAT-IO_REGISTERS] & 0xF8) | 1 | ((lines == bus->read(LYC)) << 2);
+            bus->IOrange[STAT-IO_REGISTERS] = (bus->IOrange[STAT-IO_REGISTERS] & 0xF8) | 1 | (lyc_match << 2);
 
             }
 
@@ -126,14 +149,14 @@ namespace GBC {
 
     // TODO clean this up, and fix it
     void PPU::draw_pixel() {
-        byte bgenable = bus->read(LCDC) & 1,
-             objenable = bus->read(LCDC) & (1 << 1),
-             windowenable = bus->read(LCDC) & (1 << 5);
+        byte bgenable = cached_LCDC & 1,
+             objenable = cached_LCDC & (1 << 1),
+             windowenable = cached_LCDC & (1 << 5);
 
-        byte wx = bus->read(WX),
-             wy = bus->read(WY),
-             scx = bus->read(SCX),
-             scy = bus->read(SCY);
+        byte wx = cached_WX,
+             wy = cached_WY,
+             scx = cached_SCX,
+             scy = cached_SCY;
 
         if (windowenable && bgenable && !wlyenabled && ((renderX+1 >= wx) && (lines >= wy))) {
             wlyenabled = true;
@@ -162,8 +185,8 @@ namespace GBC {
             winbgpal = 0;
         }
         
-        objpix = ((((objpal >> 4) & 1) ? bus->read_privledged(OBP1) : bus->read_privledged(OBP0)) >> ((objpal&03) * 2)) & 0x3;
-        winbgpix = (bus->read(BGP) >> (winbgpal*2))&0x3;
+        objpix = ((((objpal >> 4) & 1) ? cached_OBP1 : cached_OBP0) >> ((objpal&03) * 2)) & 0x3;
+        winbgpix = (cached_BGP >> (winbgpal*2))&0x3;
 
         if (objenable) {
             if (((((objpal&3) == 0) ||(objpal & 0x80)) && (winbgpal != 0)) || (objpal == (1 << 5))) {
@@ -177,15 +200,14 @@ namespace GBC {
         }
 
         if (debug_render) {
-            objpal = (((objpal >> 4) & 1 ? bus->read_privledged(OBP1) : bus->read_privledged(OBP0)) >> ((objpal&03) * 2)) & 0x3;
+            objpal = (((objpal >> 4) & 1 ? cached_OBP1 : cached_OBP0) >> ((objpal&03) * 2)) & 0x3;
             SDL_SetRenderDrawColor(debug_object_renderer, 255-(255.0/3)*(objpal), 255-(255.0/3)*(objpal), 255-(255.0/3)*(objpal), 255);
             SDL_RenderPoint(debug_object_renderer,renderX-6, lines);    
 
-            winpal = (bus->read(BGP) >> (winpal*2))&0x3;
+            winpal = (cached_BGP >> (winpal*2))&0x3;
             SDL_SetRenderDrawColor(debug_window_renderer, 255-(255.0/3)*(winpal), 255-(255.0/3)*(winpal), 255-(255.0/3)*(winpal), 255);
             SDL_RenderPoint(debug_window_renderer,renderX-6, lines);    
         }
-        
         
         SDL_SetRenderDrawColor(renderer, 255-(255.0/3)*(pixel), 255-(255.0/3)*(pixel), 255-(255.0/3)*(pixel), 255);
         SDL_RenderPoint(renderer,renderX++-6, lines);   
@@ -194,7 +216,7 @@ namespace GBC {
     // TODO fix issues
     inline byte PPU::objFIFO() {
         byte tilei = 255;
-        byte objsize = (bus->read(LCDC) & (1 << 2)) ? 16 : 8;
+        byte objsize = (cached_LCDC & (1 << 2)) ? 16 : 8;
         
         uint8_t tilex = 0;
 
@@ -238,10 +260,10 @@ namespace GBC {
     }
 
     inline byte PPU::bgFIFO(half tilex, half tiley) {
-        byte bgenable = bus->read(LCDC) & 1;
+        byte bgenable = cached_LCDC & 1;
 
-        half BG_tile_map = (bus->read(LCDC) & (1 << 3)) ? 0x9C00 : 0x9800;
-        byte data_area = (bus->read(LCDC) & (1 << 4));
+        half BG_tile_map = (cached_LCDC & (1 << 3)) ? 0x9C00 : 0x9800;
+        byte data_area = (cached_LCDC & (1 << 4));
 
         
         half tile_index_index = (tilex/8)+((tiley)/8)*32 + BG_tile_map;
@@ -249,46 +271,49 @@ namespace GBC {
         byte tile_index = bus->read(tile_index_index);
 
         byte tilelow, tilehigh;
+        uint8_t tiley_mod8 = tiley & 7;
+        uint8_t tilex_mod8 = tilex & 7;
 
         if (data_area != 0) {
-            tilelow = bus->read(tile_index*16+(tiley%8)*2+0x8000);
-            tilehigh = bus->read(tile_index*16+(tiley%8)*2+1+0x8000);
+            tilelow = bus->read(tile_index*16+tiley_mod8*2+0x8000);
+            tilehigh = bus->read(tile_index*16+tiley_mod8*2+1+0x8000);
         } else {
-
-            tilelow = bus->read((tiley%8)*2+0x9000+((int8_t)tile_index)*16);
-            tilehigh = bus->read((tiley%8)*2+1+0x9000+((int8_t)tile_index)*16);
+            tilelow = bus->read(tiley_mod8*2+0x9000+((int8_t)tile_index)*16);
+            tilehigh = bus->read(tiley_mod8*2+1+0x9000+((int8_t)tile_index)*16);
         }
 
-        byte final_pixel = (((1 << (7-tilex%8)) & tilelow) != 0) | ((((1 << (7-tilex%8)) & tilehigh) != 0) << 1);
+        byte final_pixel = (((1 << (7-tilex_mod8)) & tilelow) != 0) | ((((1 << (7-tilex_mod8)) & tilehigh) != 0) << 1);
         return final_pixel;
     }
 
     inline byte PPU::windowFIFO(half tilex, half tiley) {
-        byte windowEnable = (bus->read(LCDC) & (1 << 5));
+        byte windowEnable = (cached_LCDC & (1 << 5));
 
-        half w_tile_map = (bus->read(LCDC) & (1 << 6)) ? 0x9C00 : 0x9800;  
-        byte data_area = (bus->read(LCDC) & (1 << 4));
+        half w_tile_map = (cached_LCDC & (1 << 6)) ? 0x9C00 : 0x9800;  
+        byte data_area = (cached_LCDC & (1 << 4));
 
         half tile_index_index = (tilex/8)+((tiley)/8)*32;
 
         byte tile_index = bus->read(tile_index_index+w_tile_map);
 
         byte tilelow, tilehigh;
+        uint8_t tiley_mod8 = tiley & 7;
+        uint8_t tilex_mod8 = tilex & 7;
 
         if (data_area) {
-            tilelow = bus->read(tile_index*16+(tiley%8)*2+0x8000);
-            tilehigh = bus->read(tile_index*16+(tiley%8)*2+1+0x8000);
+            tilelow = bus->read(tile_index*16+tiley_mod8*2+0x8000);
+            tilehigh = bus->read(tile_index*16+tiley_mod8*2+1+0x8000);
         } else {
             if (tile_index <= 127) {
-                tilelow = bus->read((tiley%8)*2+0x9000+tile_index*16);
-                tilehigh = bus->read((tiley%8)*2+1+0x9000+tile_index*16);
+                tilelow = bus->read(tiley_mod8*2+0x9000+tile_index*16);
+                tilehigh = bus->read(tiley_mod8*2+1+0x9000+tile_index*16);
             } else {
-                tilelow = bus->read((tiley%8)*2+0x9000+((int8_t)tile_index)*16);
-                tilehigh = bus->read((tiley%8)*2+1+0x9000+((int8_t)tile_index)*16);
+                tilelow = bus->read(tiley_mod8*2+0x9000+((int8_t)tile_index)*16);
+                tilehigh = bus->read(tiley_mod8*2+1+0x9000+((int8_t)tile_index)*16);
             }
         }
 
-        byte final_pixel = (((1 << (7-tilex%8)) & tilelow) != 0) | ((((1 << (7-tilex%8)) & tilehigh) != 0) << 1);
+        byte final_pixel = (((1 << (7-tilex_mod8)) & tilelow) != 0) | ((((1 << (7-tilex_mod8)) & tilehigh) != 0) << 1);
 
         return final_pixel; 
     }

--- a/src/video/PPU.h
+++ b/src/video/PPU.h
@@ -58,10 +58,23 @@ namespace GBC {
 
         void init_debug_window();
         void render_debug();
+        void mark_cache_dirty() { cache_dirty = true; }
 
         private: 
         obj objbuffer[10];
         uint8_t objnum = 0;
+        byte cached_LCDC = 0;
+        byte cached_BGP = 0;
+        byte cached_OBP0 = 0;
+        byte cached_OBP1 = 0;
+        byte cached_SCX = 0;
+        byte cached_SCY = 0;
+        byte cached_WX = 0;
+        byte cached_WY = 0;
+        byte cached_LYC = 0;
+        bool cache_dirty = true;
+        bool lyc_match = false;
+        inline void update_register_cache();
         inline byte objFIFO();
         inline byte bgFIFO(half tilex, half tiley);
         inline byte windowFIFO(half tilex, half tiley);


### PR DESCRIPTION
Implement a comprehensive emulator optimization plan, focusing on CPU/PPU caching, memory access routing, and conditional debug compilation, to improve overall performance.

This PR addresses several critical and high-priority items from the optimization plan, including caching CPU interrupt flags and PPU registers per scanline, reordering memory access checks for common cases, adding inlining hints to hot functions, and conditionally compiling debug code to reduce overhead in release and web builds.

---
<a href="https://cursor.com/background-agent?bcId=bc-3ad1dcdf-2272-4ff5-8982-3873324cdab2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3ad1dcdf-2272-4ff5-8982-3873324cdab2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Caches CPU interrupt flags and PPU registers, reorders MMU read/write checks, adds inlining and web build flags, and gates input/debug for faster execution.
> 
> - **Performance**:
>   - **CPU (`src/CPU/SM83.*`)**: Cache interrupt flags (`cached_interrupt_flags`) and use them for IME/interrupt dispatch; switch LDH ops to `IO_REGISTERS`; add `always_inline` hints to hot paths.
>   - **PPU (`src/video/PPU.*`)**: Add per-scanline register cache (e.g., `cached_LCDC/BGP/OBP0/OBP1/SCX/SCY/WX/WY/LYC`) with `update_register_cache()`; compute `lyc_match` once; use cached values in `draw_pixel`, `objFIFO`, `bgFIFO`, `windowFIFO`; small math optimizations (`*_mod8`).
>   - **MMU (`src/MMU/bus.cc`)**: Reorder `read`/`write` address-range checks to prioritize common RAM/ROM paths; streamline ECHO handling; defer external RAM handling.
>   - **Core Loop (`src/GBC.*`)**: Add `execute_frame()`; batch cycles and early-break on vblank; reduce input polling frequency; wrap input/debug under `#ifndef __EMSCRIPTEN__`.
> - **Build**:
>   - **CMake**: Add Emscripten-specific `-O3 -flto` compile/link flags and runtime options; default native `-O3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3323f8466f2e89f1fc13768aead79a2c32048771. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->